### PR TITLE
Fix Duration Marshal methods to handle millisecond durations

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -12,12 +12,10 @@ type Duration time.Duration
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (dur Duration) MarshalText() ([]byte, error) {
-	s := int(dur / Duration(time.Second))
-	ms := int(dur) - s*int(time.Second)
-	h := int(s / 3600)
-	s = s % 3600
-	m := int(s / 60)
-	s = s % 60
+	h := dur / Duration(time.Hour)
+	m := dur % Duration(time.Hour) / Duration(time.Minute)
+	s := dur % Duration(time.Minute) / Duration(time.Second)
+	ms := dur % Duration(time.Second) / Duration(time.Millisecond)
 	if ms == 0 {
 		return []byte(fmt.Sprintf("%02d:%02d:%02d", h, m, s)), nil
 	}
@@ -36,7 +34,7 @@ func (dur *Duration) UnmarshalText(data []byte) (err error) {
 			return fmt.Errorf("invalid duration: %s", data)
 		}
 		parts[2] = parts[2][:i]
-		*dur += Duration(ms)
+		*dur += Duration(ms) * Duration(time.Millisecond)
 	}
 	f := Duration(time.Second)
 	for i := 2; i >= 0; i-- {

--- a/duration_test.go
+++ b/duration_test.go
@@ -12,6 +12,10 @@ func TestDurationMarshaler(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, "00:00:00", string(b))
 	}
+	b, err = Duration(2 * time.Millisecond).MarshalText()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "00:00:00.002", string(b))
+	}
 	b, err = Duration(2 * time.Second).MarshalText()
 	if assert.NoError(t, err) {
 		assert.Equal(t, "00:00:02", string(b))
@@ -23,10 +27,6 @@ func TestDurationMarshaler(t *testing.T) {
 	b, err = Duration(2 * time.Hour).MarshalText()
 	if assert.NoError(t, err) {
 		assert.Equal(t, "02:00:00", string(b))
-	}
-	b, err = Duration(2*time.Hour + 123).MarshalText()
-	if assert.NoError(t, err) {
-		assert.Equal(t, "02:00:00.123", string(b))
 	}
 }
 
@@ -48,8 +48,8 @@ func TestDurationUnmarshal(t *testing.T) {
 		assert.Equal(t, Duration(2*time.Hour), d)
 	}
 	d = 0
-	if assert.NoError(t, d.UnmarshalText([]byte("02:00:00.123"))) {
-		assert.Equal(t, Duration(2*time.Hour+123), d)
+	if assert.NoError(t, d.UnmarshalText([]byte("00:00:00.123"))) {
+		assert.Equal(t, Duration(123*time.Millisecond), d)
 	}
 	assert.EqualError(t, d.UnmarshalText([]byte("00:00:60")), "invalid duration: 00:00:60")
 	assert.EqualError(t, d.UnmarshalText([]byte("00:60:00")), "invalid duration: 00:60:00")


### PR DESCRIPTION
Hi,

It appears that the Duration.MarshalText() and Duration.UnmarshalText() 
methods handle milliseconds, as nanoseconds on the underlying type's
value. The methods work when converting back and forth, but if you try
to access the underlying Duration value, the milliseconds are stored in the
nanoseconds unit.

Eg:

```go
package main

import (
        "fmt"
        "github.com/rs/vast"
)

func main() {
        var dur vast.Duration
        sample := "00:00:01.314"

        _ = dur.UnmarshalText([]byte(sample))
        text, _ := dur.MarshalText()

        fmt.Printf("sample:  %v\n", sample)
        fmt.Printf("marshal: %s\n", text)
        fmt.Printf("dur val: %v\n", dur)
        fmt.Printf("expect:  1314000000\n")
}
```

Outputs:

```
sample:  00:00:01.314
marshal: 00:00:01.314
dur val: 1000000314
expect:  1314000000
```

The corresponding tests also have a similar issue where they add fixed values without multiplying by time.Millisecond (as they do when adding hours via `2*time.Hour`) which makes me thing this behaviour isn't desired.

This PR changes this behaviour on the marshal methods, adjusts the tests. This also makes a few more (unnecessary) changes to the MarshalText method to make the time conversion more concise (IMHO), specifically it adjusts the method to calculate hours, minutes and seconds. These last changes aren't required though, but makes them consistent with the adjust millisecond method which was required.