### PR TITLE
undefined return 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# ignore vscode files
+.vscode/
+debug.test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-# ignore vscode files
-.vscode/
-debug.test

--- a/duration.go
+++ b/duration.go
@@ -24,7 +24,12 @@ func (dur Duration) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (dur *Duration) UnmarshalText(data []byte) (err error) {
-	parts := strings.SplitN(string(data), ":", 3)
+	s := string(data)
+	if s == "" || strings.ToLower(s) == "undefined" {
+		*dur = 0
+		return nil
+	}
+	parts := strings.SplitN(s, ":", 3)
 	if len(parts) != 3 {
 		return fmt.Errorf("invalid duration: %s", data)
 	}

--- a/duration_test.go
+++ b/duration_test.go
@@ -51,6 +51,14 @@ func TestDurationUnmarshal(t *testing.T) {
 	if assert.NoError(t, d.UnmarshalText([]byte("00:00:00.123"))) {
 		assert.Equal(t, Duration(123*time.Millisecond), d)
 	}
+	d = 0
+	if assert.NoError(t, d.UnmarshalText([]byte("undefined"))) {
+		assert.Equal(t, Duration(0), d)
+	}
+	d = 0
+	if assert.NoError(t, d.UnmarshalText([]byte(""))) {
+		assert.Equal(t, Duration(0), d)
+	}
 	assert.EqualError(t, d.UnmarshalText([]byte("00:00:60")), "invalid duration: 00:00:60")
 	assert.EqualError(t, d.UnmarshalText([]byte("00:60:00")), "invalid duration: 00:60:00")
 	assert.EqualError(t, d.UnmarshalText([]byte("00:00:00.-1")), "invalid duration: 00:00:00.-1")

--- a/testdata/vast_inline_linear-duration_undefined.xml
+++ b/testdata/vast_inline_linear-duration_undefined.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VAST version="2.0">
+  <Ad id="601364">
+  <InLine>
+    <AdSystem version="1.0">Acudeo Compatible</AdSystem>
+    <AdTitle>VAST 2.0 Instream Test 1</AdTitle>
+	<Creatives>
+		<Creative AdID="601364">
+			<Linear>
+				<Duration>undefined</Duration>
+				<MediaFiles>
+					<MediaFile delivery="progressive" type="video/x-flv" bitrate="500" width="400" height="300" scalable="true" maintainAspectRatio="true">http://cdnp.tremormedia.com/video/acudeo/Carrot_400x300_500kb.flv</MediaFile>
+				</MediaFiles>
+			</Linear>
+		</Creative>
+	</Creatives>
+  </InLine>
+  </Ad>
+</VAST>

--- a/vast_test.go
+++ b/vast_test.go
@@ -122,6 +122,28 @@ func TestInlineLinear(t *testing.T) {
 	}
 }
 
+func TestInlineLinearDurationUndefined(t *testing.T) {
+	v, err := loadFixture("testdata/vast_inline_linear-duration_undefined.xml")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "2.0", v.Version)
+	if assert.Len(t, v.Ads, 1) {
+		ad := v.Ads[0]
+		if assert.NotNil(t, ad.InLine) {
+			inline := ad.InLine
+			if assert.Len(t, inline.Creatives, 1) {
+				crea1 := inline.Creatives[0]
+				if assert.NotNil(t, crea1.Linear) {
+					linear := crea1.Linear
+					assert.Equal(t, Duration(0), linear.Duration)
+				}
+			}
+		}
+	}
+}
+
 func TestInlineNonLinear(t *testing.T) {
 	v, err := loadFixture("testdata/vast_inline_nonlinear.xml")
 	if !assert.NoError(t, err) {


### PR DESCRIPTION
When a linear duration was `undefined`, the vast failed to decode due to the error being thrown. In the case where the duration failed to decode, the time is returned as -1 instead of throwing an error.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<VAST version="2.0">
  <Ad id="601364">
  <InLine>
    <AdSystem version="1.0">Acudeo Compatible</AdSystem>
    <AdTitle>VAST 2.0 Instream Test 1</AdTitle>
	<Creatives>
		<Creative AdID="601364">
			<Linear>
				<Duration>undefined</Duration>
				<MediaFiles>
					<MediaFile delivery="progressive" type="video/x-flv" bitrate="500" width="400" height="300" scalable="true" maintainAspectRatio="true">http://cdnp.tremormedia.com/video/acudeo/Carrot_400x300_500kb.flv</MediaFile>
				</MediaFiles>
			</Linear>
		</Creative>
	</Creatives>
  </InLine>
  </Ad>
</VAST>
```