### PR TITLE
Fix InLine>Pricing type from string to Pricing

### DIFF
--- a/vast.go
+++ b/vast.go
@@ -73,7 +73,7 @@ type InLine struct {
 	// Provides a value that represents a price that can be used by real-time bidding
 	// (RTB) systems. VAST is not designed to handle RTB since other methods exist,
 	// but this element is offered for custom solutions if needed.
-	Pricing string `xml:",omitempty"`
+	Pricing Pricing `xml:",omitempty"`
 	// XML node for custom extensions, as defined by the ad server. When used, a
 	// custom element should be nested under <Extensions> to help separate custom
 	// XML elements from VAST elements. The following example includes a custom


### PR DESCRIPTION
According to VASTv3_0 document page 19 and 67, the type for `InLine>Pricing` should be struct type `Pricing` instead of `string`.