### PR TITLE
Changed pricing field to be a pointer to get empty values omitted.

### DIFF
--- a/vast.go
+++ b/vast.go
@@ -73,7 +73,7 @@ type InLine struct {
 	// Provides a value that represents a price that can be used by real-time bidding
 	// (RTB) systems. VAST is not designed to handle RTB since other methods exist,
 	// but this element is offered for custom solutions if needed.
-	Pricing Pricing `xml:",omitempty"`
+	Pricing *Pricing `xml:",omitempty"`
 	// XML node for custom extensions, as defined by the ad server. When used, a
 	// custom element should be nested under <Extensions> to help separate custom
 	// XML elements from VAST elements. The following example includes a custom


### PR DESCRIPTION
The [IAB VAST Validator](https://vastvalidator.iabtechlab.com/dash) (for V3) disallows having a pricing tag without pricing information.