### PR TITLE
Changed iframe resource field to be a pointer to get empty values omitted.

### DIFF
--- a/vast.go
+++ b/vast.go
@@ -287,7 +287,7 @@ type Companion struct {
 	// URL to a static file, such as an image or SWF file
 	StaticResource *StaticResource `xml:",omitempty"`
 	// URL source for an IFrame to display the companion element
-	IFrameResource CDATAString `xml:",omitempty"`
+	IFrameResource *CDATAString `xml:",omitempty"`
 	// HTML to display the companion element
 	HTMLResource *HTMLResource `xml:",omitempty"`
 }

--- a/vast.go
+++ b/vast.go
@@ -426,7 +426,7 @@ type Icon struct {
 	// URL to a static file, such as an image or SWF file
 	StaticResource *StaticResource `xml:",omitempty"`
 	// URL source for an IFrame to display the companion element
-	IFrameResource CDATAString `xml:",omitempty"`
+	IFrameResource *CDATAString `xml:",omitempty"`
 	// HTML to display the companion element
 	HTMLResource *HTMLResource `xml:",omitempty"`
 }

--- a/vast.go
+++ b/vast.go
@@ -287,7 +287,7 @@ type Companion struct {
 	// URL to a static file, such as an image or SWF file
 	StaticResource *StaticResource `xml:",omitempty"`
 	// URL source for an IFrame to display the companion element
-	IFrameResource CDATAString `xml:",omitempty"`
+	IFrameResource *CDATAString `xml:",omitempty"`
 	// HTML to display the companion element
 	HTMLResource *HTMLResource `xml:",omitempty"`
 }
@@ -426,7 +426,7 @@ type Icon struct {
 	// URL to a static file, such as an image or SWF file
 	StaticResource *StaticResource `xml:",omitempty"`
 	// URL source for an IFrame to display the companion element
-	IFrameResource CDATAString `xml:",omitempty"`
+	IFrameResource *CDATAString `xml:",omitempty"`
 	// HTML to display the companion element
 	HTMLResource *HTMLResource `xml:",omitempty"`
 }

--- a/vast_test.go
+++ b/vast_test.go
@@ -203,6 +203,7 @@ func TestInlineLinear(t *testing.T) {
 						if assert.NotNil(t, comp1.StaticResource) {
 							assert.Equal(t, "image/jpeg", comp1.StaticResource.CreativeType)
 							assert.Equal(t, "http://demo.tremormedia.com/proddev/vast/Blistex1.jpg", comp1.StaticResource.URI)
+							assert.Nil(t, comp1.IFrameResource)
 						}
 						if assert.Len(t, comp1.TrackingEvents, 1) {
 							assert.Equal(t, "creativeView", comp1.TrackingEvents[0].Event)
@@ -605,6 +606,7 @@ func TestIcons(t *testing.T) {
 							assert.Equal(t, "image/png", icon1.StaticResource.CreativeType)
 							assert.Equal(t, "https://s.aolcdn.com/ads/adchoices.png", icon1.StaticResource.URI)
 							assert.Equal(t, "https://adinfo.aol.com", icon1.IconClickThrough.CDATA)
+							assert.Nil(t, icon1.IFrameResource)
 						}
 					}
 				}


### PR DESCRIPTION
change iframe resource field to be a pointer, because it is not required field. 
