### PR TITLE
Remove CDATA wrapper for AdSystem

### DIFF
--- a/testdata/vast4_universal_ad_id.xml
+++ b/testdata/vast4_universal_ad_id.xml
@@ -1,0 +1,54 @@
+<VAST version="4.0" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns="http://www.iab.com/VAST">
+  <Ad id="20008" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Extensions>
+        <Extension type="iab-Count">
+          <total_available>
+            <![CDATA[ 2 ]]>
+          </total_available>
+        </Extension>
+      </Extensions>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>iabtechlab video ad</AdTitle>
+      <Category authority="http://www.iabtechlab.com/categoryauthority">AD CONTENT description category</Category>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="08:34:01">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+              </MediaFile>
+              <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4]]>
+              </MediaFile>
+              <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-low-resolution.mp4]]>
+              </MediaFile>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
+</VAST>

--- a/vast.go
+++ b/vast.go
@@ -257,17 +257,17 @@ type Companion struct {
 	// Optional identifier
 	ID string `xml:"id,attr,omitempty"`
 	// Pixel dimensions of companion slot.
-	Width int `xml:"width,attr"`
+	Width int `xml:"width,attr,omitempty"`
 	// Pixel dimensions of companion slot.
-	Height int `xml:"height,attr"`
+	Height int `xml:"height,attr,omitempty"`
 	// Pixel dimensions of the companion asset.
-	AssetWidth int `xml:"assetWidth,attr"`
+	AssetWidth int `xml:"assetWidth,attr,omitempty"`
 	// Pixel dimensions of the companion asset.
-	AssetHeight int `xml:"assetHeight,attr"`
+	AssetHeight int `xml:"assetHeight,attr,omitempty"`
 	// Pixel dimensions of expanding companion ad when in expanded state.
-	ExpandedWidth int `xml:"expandedWidth,attr"`
+	ExpandedWidth int `xml:"expandedWidth,attr,omitempty"`
 	// Pixel dimensions of expanding companion ad when in expanded state.
-	ExpandedHeight int `xml:"expandedHeight,attr"`
+	ExpandedHeight int `xml:"expandedHeight,attr,omitempty"`
 	// The apiFramework defines the method to use for communication with the companion.
 	APIFramework string `xml:"apiFramework,attr,omitempty"`
 	// Used to match companion creative to publisher placement areas on the page.

--- a/vast.go
+++ b/vast.go
@@ -78,7 +78,7 @@ type InLine struct {
 	// custom element should be nested under <Extensions> to help separate custom
 	// XML elements from VAST elements. The following example includes a custom
 	// xml element within the Extensions element.
-	Extensions []Extension `xml:"Extensions>Extension,omitempty"`
+	Extensions *[]Extension `xml:"Extensions>Extension,omitempty"`
 }
 
 // Impression is a URI that directs the video player to a tracking resource file that
@@ -167,7 +167,7 @@ type Creative struct {
 	// of VAST.
 	// The nested <CreativeExtension> includes an attribute for type, which
 	// specifies the MIME type needed to execute the extension.
-	CreativeExtensions []Extension `xml:"CreativeExtensions>CreativeExtension,omitempty"`
+	CreativeExtensions *[]Extension `xml:"CreativeExtensions>CreativeExtension,omitempty"`
 }
 
 // CompanionAds contains companions creatives

--- a/vast.go
+++ b/vast.go
@@ -73,7 +73,7 @@ type InLine struct {
 	// Provides a value that represents a price that can be used by real-time bidding
 	// (RTB) systems. VAST is not designed to handle RTB since other methods exist,
 	// but this element is offered for custom solutions if needed.
-	Pricing Pricing `xml:",omitempty"`
+	Pricing *Pricing `xml:",omitempty"`
 	// XML node for custom extensions, as defined by the ad server. When used, a
 	// custom element should be nested under <Extensions> to help separate custom
 	// XML elements from VAST elements. The following example includes a custom

--- a/vast.go
+++ b/vast.go
@@ -156,6 +156,8 @@ type Creative struct {
 	CompanionAds *CompanionAds `xml:",omitempty"`
 	// If defined, defines non linear creatives
 	NonLinearAds *NonLinearAds `xml:",omitempty"`
+	// If present, provides a VAST 4.x universal ad id
+	UniversalAdID *UniversalAdID `xml:"UniversalAdId,omitempty"`
 	// When an API framework is needed to execute creative, a
 	// <CreativeExtensions> element can be added under the <Creative>. This
 	// extension can be used to load an executable creative with or without using
@@ -515,4 +517,11 @@ type MediaFile struct {
 	// placed in key/value pairs on the asset request).
 	APIFramework string `xml:"apiFramework,attr,omitempty"`
 	URI          string `xml:",cdata"`
+}
+
+// UniversalAdID describes a VAST 4.x universal ad id.
+type UniversalAdID struct {
+	IDRegistry string `xml:"idRegistry,attr"`
+	IDValue    string `xml:"idValue,attr"`
+	ID         string `xml:",cdata"`
 }

--- a/vast.go
+++ b/vast.go
@@ -44,7 +44,7 @@ type CDATAString struct {
 // URIs necessary to display the ad.
 type InLine struct {
 	// The name of the ad server that returned the ad
-	AdSystem *AdSystem
+	AdSystem string `xml:",omitempty"`
 	// The common name of the ad
 	AdTitle CDATAString
 	// One or more URIs that directs the video player to a tracking resource file that the
@@ -112,7 +112,7 @@ type Pricing struct {
 // the ad.
 type Wrapper struct {
 	// The name of the ad server that returned the ad
-	AdSystem *AdSystem
+	AdSystem string `xml:",omitempty"`
 	// URL of ad tag of downstream Secondary Ad Server
 	VASTAdTagURI CDATAString
 	// One or more URIs that directs the video player to a tracking resource file that the

--- a/vast_test.go
+++ b/vast_test.go
@@ -612,3 +612,28 @@ func TestIcons(t *testing.T) {
 		}
 	}
 }
+
+func TestUniversalAdID(t *testing.T) {
+	v, _, _, err := loadFixture("testdata/vast4_universal_ad_id.xml")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "4.0", v.Version)
+	if assert.Len(t, v.Ads, 1) {
+		ad := v.Ads[0]
+		assert.Equal(t, "20008", ad.ID)
+		if assert.NotNil(t, ad.InLine) {
+			if assert.NotNil(t, ad.InLine.Extensions) {
+				if assert.Len(t, ad.InLine.Creatives, 1) {
+					if assert.NotNil(t, ad.InLine.Creatives[0].UniversalAdID) {
+						creative := ad.InLine.Creatives[0]
+						assert.Equal(t, "Ad-ID", creative.UniversalAdID.IDRegistry)
+						assert.Equal(t, "8465", creative.UniversalAdID.IDValue)
+						assert.Equal(t, "8465", creative.UniversalAdID.ID)
+					}
+				}
+			}
+		}
+	}
+}

--- a/vast_test.go
+++ b/vast_test.go
@@ -43,15 +43,16 @@ func TestCreativeExtensions(t *testing.T) {
 		assert.Equal(t, "abc123", ad.ID)
 		if assert.NotNil(t, ad.InLine) {
 			if assert.Len(t, ad.InLine.Creatives, 1) {
-				if assert.Len(t, ad.InLine.Creatives[0].CreativeExtensions, 4) {
+				exts := *ad.InLine.Creatives[0].CreativeExtensions
+				if assert.Len(t, exts, 4) {
 					var ext Extension
 					// asserting first extension
-					ext = ad.InLine.Creatives[0].CreativeExtensions[0]
+					ext = exts[0]
 					assert.Equal(t, "geo", ext.Type)
 					assert.Empty(t, ext.CustomTracking)
 					assert.Equal(t, "\n              <Country>US</Country>\n              <Bandwidth>3</Bandwidth>\n              <BandwidthKbps>1680</BandwidthKbps>\n            ", string(ext.Data))
 					// asserting second extension
-					ext = ad.InLine.Creatives[0].CreativeExtensions[1]
+					ext = exts[1]
 					assert.Equal(t, "activeview", ext.Type)
 					if assert.Len(t, ext.CustomTracking, 2) {
 						// first tracker
@@ -63,12 +64,12 @@ func TestCreativeExtensions(t *testing.T) {
 					}
 					assert.Empty(t, string(ext.Data))
 					// asserting third extension
-					ext = ad.InLine.Creatives[0].CreativeExtensions[2]
+					ext = exts[2]
 					assert.Equal(t, "DFP", ext.Type)
 					assert.Empty(t, ext.CustomTracking)
 					assert.Equal(t, "\n              <SkippableAdType>Generic</SkippableAdType>\n            ", string(ext.Data))
 					// asserting fourth extension
-					ext = ad.InLine.Creatives[0].CreativeExtensions[3]
+					ext = exts[3]
 					assert.Equal(t, "metrics", ext.Type)
 					assert.Empty(t, ext.CustomTracking)
 					assert.Equal(t, "\n              <FeEventId>MubmWKCWLs_tiQPYiYrwBw</FeEventId>\n              <AdEventId>CIGpsPCTkdMCFdN-Ygod-xkCKQ</AdEventId>\n            ", string(ext.Data))
@@ -90,15 +91,16 @@ func TestInlineExtensions(t *testing.T) {
 		assert.Equal(t, "708365173", ad.ID)
 		if assert.NotNil(t, ad.InLine) {
 			if assert.NotNil(t, ad.InLine.Extensions) {
-				if assert.Len(t, ad.InLine.Extensions, 4) {
+				exts := *ad.InLine.Extensions
+				if assert.Len(t, exts, 4) {
 					var ext Extension
 					// asserting first extension
-					ext = ad.InLine.Extensions[0]
+					ext = exts[0]
 					assert.Equal(t, "geo", ext.Type)
 					assert.Empty(t, ext.CustomTracking)
 					assert.Equal(t, "\n          <Country>US</Country>\n          <Bandwidth>3</Bandwidth>\n          <BandwidthKbps>1680</BandwidthKbps>\n        ", string(ext.Data))
 					// asserting second extension
-					ext = ad.InLine.Extensions[1]
+					ext = exts[1]
 					assert.Equal(t, "activeview", ext.Type)
 					if assert.Len(t, ext.CustomTracking, 2) {
 						// first tracker
@@ -110,12 +112,12 @@ func TestInlineExtensions(t *testing.T) {
 					}
 					assert.Empty(t, string(ext.Data))
 					// asserting third extension
-					ext = ad.InLine.Extensions[2]
+					ext = exts[2]
 					assert.Equal(t, "DFP", ext.Type)
 					assert.Equal(t, "\n          <SkippableAdType>Generic</SkippableAdType>\n        ", string(ext.Data))
 					assert.Empty(t, ext.CustomTracking)
 					// asserting fourth extension
-					ext = ad.InLine.Extensions[3]
+					ext = exts[3]
 					assert.Equal(t, "metrics", ext.Type)
 					assert.Equal(t, "\n          <FeEventId>MubmWKCWLs_tiQPYiYrwBw</FeEventId>\n          <AdEventId>CIGpsPCTkdMCFdN-Ygod-xkCKQ</AdEventId>\n        ", string(ext.Data))
 					assert.Empty(t, ext.CustomTracking)
@@ -519,11 +521,12 @@ func TestSpotXVpaid(t *testing.T) {
 				}
 
 			}
-			if assert.Len(t, inline.Extensions, 2) {
-				ext1 := inline.Extensions[0]
+			exts := *inline.Extensions
+			if assert.Len(t, exts, 2) {
+				ext1 := exts[0]
 				assert.Equal(t, "LR-Pricing", ext1.Type)
 				assert.Equal(t, "<Price model=\"CPM\" currency=\"USD\" source=\"spotxchange\"><![CDATA[3.06]]></Price>", strings.TrimSpace(string(ext1.Data)))
-				ext2 := inline.Extensions[1]
+				ext2 := exts[1]
 				assert.Equal(t, "SpotX-Count", ext2.Type)
 				assert.Equal(t, "<total_available><![CDATA[1]]></total_available>", strings.TrimSpace(string(ext2.Data)))
 			}


### PR DESCRIPTION
Currently we serve ad markup with CDATA wrapped AdSystem:
```
<AdSystem><![CDATA[Unity Ads]]></AdSystem>
```

According to VAST spec:
> All URIs or any other free text fields containing potentially dangerous characters contained in the VAST document should be wrapped in CDATA blocks. The VAST response should be carefully tested for appropriate treatment of URI characters that require special handling.

There is nothing wrong with such wrapper, but there is also no need for that because we don't use any special characters. On the other hand, that's not typical XML in examples I've seen in AdX - no one uses CDATA wrapper. My concern is that this may lead to unknown issues, so better avoid this uncertainty especially as we don't need this functionality.

For example, from AdSence:
```
<InLine>
    <AdSystem>AdSense/AdX</AdSystem>
    <AdTitle>149555</AdTitle>
```