### PR TITLE
Pricing in wrapper

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -26,30 +26,58 @@ func (dur Duration) MarshalText() ([]byte, error) {
 func (dur *Duration) UnmarshalText(data []byte) (err error) {
 	s := string(data)
 	s = strings.TrimSpace(s)
+
+	// First chek for bogus data.
 	if s == "" || strings.ToLower(s) == "undefined" {
 		*dur = 0
 		return nil
 	}
 	parts := strings.SplitN(s, ":", 3)
-	if len(parts) != 3 {
-		return fmt.Errorf("invalid duration: %s", data)
+	if len(parts) > 3 {
+		return fmt.Errorf("invalid duration -- too many colons: %s", data)
 	}
-	if i := strings.IndexByte(parts[2], '.'); i > 0 {
-		ms, err := strconv.ParseInt(parts[2][i+1:], 10, 32)
-		if err != nil || ms < 0 || ms > 999 {
-			return fmt.Errorf("invalid duration: %s", data)
+
+	// Extract any milliseconds from the last part and remove them from the string.
+	finalDuration := Duration(0)
+	lastPart := parts[len(parts)-1]
+	lastPartPieces := strings.Split(lastPart, ".")
+	if len(lastPartPieces) > 2 {
+		return fmt.Errorf("invalid duration -- too many periods: %s", data)
+	}
+	if len(lastPartPieces) == 2 {
+		msString := lastPartPieces[1]
+		if len(msString) > 3 {
+			return fmt.Errorf("invalid duration -- milliseconds too long: %s", data)
 		}
-		parts[2] = parts[2][:i]
-		*dur += Duration(ms) * Duration(time.Millisecond)
-	}
-	f := Duration(time.Second)
-	for i := 2; i >= 0; i-- {
-		n, err := strconv.ParseInt(parts[i], 10, 32)
-		if err != nil || n < 0 || n > 59 {
-			return fmt.Errorf("invalid duration: %s", data)
+		if len(msString) == 0 {
+			return fmt.Errorf("invalid duration -- empty milliseconds: %s", data)
 		}
-		*dur += Duration(n) * f
-		f *= 60
+		if len(msString) < 3 {
+			// Pad with zeros to ensure we have 3 digits.
+			for len(msString) < 3 {
+				msString += "0"
+			}
+			lastPartPieces[1] = msString
+		}
+		parsedMS, err := strconv.ParseInt(msString, 10, 32)
+		if err != nil || parsedMS < 0 {
+			return fmt.Errorf("invalid duration -- invalid milliseconds: %s", data)
+		}
+		finalDuration = Duration(parsedMS) * Duration(time.Millisecond)
+		parts[len(parts)-1] = lastPartPieces[0]
 	}
+
+	multipliers := []time.Duration{time.Second, time.Minute, time.Hour}[0:len(parts)]
+
+	for i, part := range parts {
+		parsedValue, err := strconv.ParseInt(part, 10, 32)
+		if err != nil || parsedValue < 0 {
+			return fmt.Errorf("invalid duration -- invalid time value: %s %s", data, part)
+		}
+		finalDuration += Duration(parsedValue) * Duration(multipliers[len(multipliers)-1-i])
+	}
+
+	*dur = finalDuration
+
 	return nil
 }

--- a/duration.go
+++ b/duration.go
@@ -27,7 +27,7 @@ func (dur *Duration) UnmarshalText(data []byte) (err error) {
 	s := string(data)
 	s = strings.TrimSpace(s)
 
-	// First chek for bogus data.
+	// First check for bogus data.
 	if s == "" || strings.ToLower(s) == "undefined" {
 		*dur = 0
 		return nil

--- a/duration_test.go
+++ b/duration_test.go
@@ -90,8 +90,20 @@ func TestDurationUnmarshal(t *testing.T) {
 	if assert.NoError(t, d.UnmarshalText([]byte("00:1:10.100"))) {
 		assert.Equal(t, Duration(1*time.Minute+10*time.Second+100*time.Millisecond), d)
 	}
+	if assert.NoError(t, d.UnmarshalText([]byte("1:10"))) {
+		assert.Equal(t, Duration(1*time.Minute+10*time.Second), d)
+	}
+	if assert.NoError(t, d.UnmarshalText([]byte("1:10.1"))) {
+		assert.Equal(t, Duration(1*time.Minute+10*time.Second+100*time.Millisecond), d)
+	}
+	if assert.NoError(t, d.UnmarshalText([]byte("1:10.10"))) {
+		assert.Equal(t, Duration(1*time.Minute+10*time.Second+100*time.Millisecond), d)
+	}
 
 	assert.EqualError(t, d.UnmarshalText([]byte("00:00:00.-1")), "invalid duration -- invalid milliseconds: 00:00:00.-1")
+	assert.EqualError(t, d.UnmarshalText([]byte("00:00:00.")), "invalid duration -- empty milliseconds: 00:00:00.")
+	assert.EqualError(t, d.UnmarshalText([]byte("00:00:12.34.56")), "invalid duration -- too many periods: 00:00:12.34.56")
+	assert.EqualError(t, d.UnmarshalText([]byte("00:00:12.34.")), "invalid duration -- too many periods: 00:00:12.34.")
 	assert.EqualError(t, d.UnmarshalText([]byte("00:00:00.1000")), "invalid duration -- milliseconds too long: 00:00:00.1000")
 	assert.EqualError(t, d.UnmarshalText([]byte("00h01m")), "invalid duration -- invalid time value: 00h01m 00h01m")
 }

--- a/duration_test.go
+++ b/duration_test.go
@@ -63,9 +63,35 @@ func TestDurationUnmarshal(t *testing.T) {
 	if assert.NoError(t, d.UnmarshalText([]byte(""))) {
 		assert.Equal(t, Duration(0), d)
 	}
-	assert.EqualError(t, d.UnmarshalText([]byte("00:00:60")), "invalid duration: 00:00:60")
-	assert.EqualError(t, d.UnmarshalText([]byte("00:60:00")), "invalid duration: 00:60:00")
-	assert.EqualError(t, d.UnmarshalText([]byte("00:00:00.-1")), "invalid duration: 00:00:00.-1")
-	assert.EqualError(t, d.UnmarshalText([]byte("00:00:00.1000")), "invalid duration: 00:00:00.1000")
-	assert.EqualError(t, d.UnmarshalText([]byte("00h01m")), "invalid duration: 00h01m")
+	if assert.NoError(t, d.UnmarshalText([]byte("00:00:60"))) {
+		assert.Equal(t, Duration(60*time.Second), d)
+	}
+	if assert.NoError(t, d.UnmarshalText([]byte("00:60:00"))) {
+		assert.Equal(t, Duration(60*time.Minute), d)
+	}
+	if assert.NoError(t, d.UnmarshalText([]byte("00:00:70"))) {
+		assert.Equal(t, Duration(70*time.Second), d)
+	}
+	if assert.NoError(t, d.UnmarshalText([]byte("00:00:70.123"))) {
+		assert.Equal(t, Duration(70*time.Second)+Duration(time.Millisecond*123), d)
+	}
+	if assert.NoError(t, d.UnmarshalText([]byte("70.123"))) {
+		assert.Equal(t, Duration(70*time.Second)+Duration(time.Millisecond*123), d)
+	}
+	if assert.NoError(t, d.UnmarshalText([]byte("70"))) {
+		assert.Equal(t, Duration(70*time.Second), d)
+	}
+	if assert.NoError(t, d.UnmarshalText([]byte("1:10.1"))) {
+		assert.Equal(t, Duration(1*time.Minute+10*time.Second+100*time.Millisecond), d)
+	}
+	if assert.NoError(t, d.UnmarshalText([]byte("1:10.100"))) {
+		assert.Equal(t, Duration(1*time.Minute+10*time.Second+100*time.Millisecond), d)
+	}
+	if assert.NoError(t, d.UnmarshalText([]byte("00:1:10.100"))) {
+		assert.Equal(t, Duration(1*time.Minute+10*time.Second+100*time.Millisecond), d)
+	}
+
+	assert.EqualError(t, d.UnmarshalText([]byte("00:00:00.-1")), "invalid duration -- invalid milliseconds: 00:00:00.-1")
+	assert.EqualError(t, d.UnmarshalText([]byte("00:00:00.1000")), "invalid duration -- milliseconds too long: 00:00:00.1000")
+	assert.EqualError(t, d.UnmarshalText([]byte("00h01m")), "invalid duration -- invalid time value: 00h01m 00h01m")
 }

--- a/extension.go
+++ b/extension.go
@@ -5,6 +5,7 @@ import "encoding/xml"
 // Extension represent arbitrary XML provided by the platform to extend the
 // VAST response or by custom trackers.
 type Extension struct {
+	Name           string     `xml:"name,attr,omitempty"`
 	Type           string     `xml:"type,attr,omitempty"`
 	CustomTracking []Tracking `xml:"CustomTracking>Tracking,omitempty"`
 	Data           []byte     `xml:",innerxml"`
@@ -14,6 +15,7 @@ type Extension struct {
 type extension Extension
 
 type extensionNoCT struct {
+	Name string `xml:"name,attr,omitempty"`
 	Type string `xml:"type,attr,omitempty"`
 	Data []byte `xml:",innerxml"`
 }
@@ -26,9 +28,9 @@ func (e Extension) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	// if we have custom trackers, we should ignore the data, if not, then we
 	// should consider only the data.
 	if len(e.CustomTracking) > 0 {
-		e2 = extension{Type: e.Type, CustomTracking: e.CustomTracking}
+		e2 = extension{Name: e.Name, Type: e.Type, CustomTracking: e.CustomTracking}
 	} else {
-		e2 = extensionNoCT{Type: e.Type, Data: e.Data}
+		e2 = extensionNoCT{Name: e.Name, Type: e.Type, Data: e.Data}
 	}
 
 	return enc.EncodeElement(e2, start)
@@ -43,6 +45,7 @@ func (e *Extension) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error
 		return err
 	}
 	// copy the type and the customTracking
+	e.Name = e2.Name
 	e.Type = e2.Type
 	e.CustomTracking = e2.CustomTracking
 	// copy the data only of customTracking is empty

--- a/extension_test.go
+++ b/extension_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 var (
-	extensionCustomTracking = []byte(`<Extension type="testCustomTracking"><CustomTracking><Tracking event="event.1"><![CDATA[http://event.1]]></Tracking><Tracking event="event.2"><![CDATA[http://event.2]]></Tracking></CustomTracking></Extension>`)
-	extensionData           = []byte(`<Extension type="testCustomTracking"><SkippableAdType>Generic</SkippableAdType></Extension>`)
+	extensionCustomTracking = []byte(`<Extension name="a.custom.extension.tracking" type="testCustomTracking"><CustomTracking><Tracking event="event.1"><![CDATA[http://event.1]]></Tracking><Tracking event="event.2"><![CDATA[http://event.2]]></Tracking></CustomTracking></Extension>`)
+	extensionData           = []byte(`<Extension name="a custom extension" type="testCustomTracking"><SkippableAdType>Generic</SkippableAdType></Extension>`)
 )
 
 func TestExtensionCustomTrackingMarshal(t *testing.T) {
 	e := Extension{
+		Name: "a.custom.extension.tracking",
 		Type: "testCustomTracking",
 		CustomTracking: []Tracking{
 			{
@@ -41,6 +42,7 @@ func TestExtensionCustomTracking(t *testing.T) {
 	assert.NoError(t, xml.Unmarshal(extensionCustomTracking, &e))
 
 	// assert the resulting extension
+	assert.Equal(t, "a.custom.extension.tracking", e.Name)
 	assert.Equal(t, "testCustomTracking", e.Type)
 	assert.Empty(t, string(e.Data))
 	if assert.Len(t, e.CustomTracking, 2) {
@@ -66,6 +68,7 @@ func TestExtensionGeneric(t *testing.T) {
 	assert.NoError(t, xml.Unmarshal(extensionData, &e))
 
 	// assert the resulting extension
+	assert.Equal(t, "a custom extension", e.Name)
 	assert.Equal(t, "testCustomTracking", e.Type)
 	assert.Equal(t, "<SkippableAdType>Generic</SkippableAdType>", string(e.Data))
 	assert.Empty(t, e.CustomTracking)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module vast
+
+go 1.23.10
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module vast
+module github.com/getredcircle/vast
 
 go 1.23.10
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/testdata/vast_wrapper_linear_1.xml
+++ b/testdata/vast_wrapper_linear_1.xml
@@ -39,6 +39,7 @@
 			</NonLinearAds>
 		</Creative>
 	</Creatives>
+	<Pricing model="cpm" currency="usd">1.471509</Pricing>
   </Wrapper>
   </Ad>
 </VAST>

--- a/testdata/vast_wrapper_nonlinear_1.xml
+++ b/testdata/vast_wrapper_nonlinear_1.xml
@@ -25,6 +25,7 @@
 			</NonLinearAds>
 		</Creative>
 	</Creatives>
+	<Pricing model="cpm" currency="usd">1.471509</Pricing>
   </Wrapper>
   </Ad>
 </VAST>

--- a/vast.go
+++ b/vast.go
@@ -50,7 +50,7 @@ type InLine struct {
 	// One or more URIs that directs the video player to a tracking resource file that the
 	// video player should request when the first frame of the ad is displayed
 	Impressions []Impression `xml:"Impression"`
-	Categories []Category `xml:"Category"`
+	Categories  []Category   `xml:"Category"`
 	// The container for one or more <Creative> elements
 	Creatives []Creative `xml:"Creatives>Creative"`
 	// A string value that provides a longer description of the ad.
@@ -84,7 +84,7 @@ type InLine struct {
 
 type Category struct {
 	Authority string `xml:"authority,attr"`
-	Value string `xml:",cdata"`
+	Value     string `xml:",cdata"`
 }
 
 // Impression is a URI that directs the video player to a tracking resource file that
@@ -134,6 +134,10 @@ type Wrapper struct {
 	// XML elements from VAST elements. The following example includes a custom
 	// xml element within the Extensions element.
 	Extensions []Extension `xml:"Extensions>Extension,omitempty"`
+	// Pricing provides a value that represents a price that can be used by real-time
+	// bidding (RTB) systems. VAST is not designed to handle RTB since other methods
+	// exist,  but this element is offered for custom solutions if needed.
+	Pricing *Pricing `xml:",omitempty"`
 
 	FallbackOnNoAd           *bool `xml:"fallbackOnNoAd,attr,omitempty"`
 	AllowMultipleAds         *bool `xml:"allowMultipleAds,attr,omitempty"`

--- a/vast.go
+++ b/vast.go
@@ -50,7 +50,7 @@ type InLine struct {
 	// One or more URIs that directs the video player to a tracking resource file that the
 	// video player should request when the first frame of the ad is displayed
 	Impressions []Impression `xml:"Impression"`
-	Categories []Category `xml:"Categories>Category"`
+	Categories []Category `xml:"Category"`
 	// The container for one or more <Creative> elements
 	Creatives []Creative `xml:"Creatives>Creative"`
 	// A string value that provides a longer description of the ad.

--- a/vast.go
+++ b/vast.go
@@ -84,7 +84,7 @@ type InLine struct {
 
 type Category struct {
 	Authority string `xml:"authority,attr"`
-	Value string `xml:","`
+	Value string `xml:",cdata"`
 }
 
 // Impression is a URI that directs the video player to a tracking resource file that

--- a/vast.go
+++ b/vast.go
@@ -50,7 +50,7 @@ type InLine struct {
 	// One or more URIs that directs the video player to a tracking resource file that the
 	// video player should request when the first frame of the ad is displayed
 	Impressions []Impression `xml:"Impression"`
-	Category Category `xml:`
+	Categories []Category `xml:"Categories>Category"`
 	// The container for one or more <Creative> elements
 	Creatives []Creative `xml:"Creatives>Creative"`
 	// A string value that provides a longer description of the ad.

--- a/vast.go
+++ b/vast.go
@@ -50,6 +50,7 @@ type InLine struct {
 	// One or more URIs that directs the video player to a tracking resource file that the
 	// video player should request when the first frame of the ad is displayed
 	Impressions []Impression `xml:"Impression"`
+	Category Category `xml:`
 	// The container for one or more <Creative> elements
 	Creatives []Creative `xml:"Creatives>Creative"`
 	// A string value that provides a longer description of the ad.
@@ -79,6 +80,11 @@ type InLine struct {
 	// XML elements from VAST elements. The following example includes a custom
 	// xml element within the Extensions element.
 	Extensions *[]Extension `xml:"Extensions>Extension,omitempty"`
+}
+
+type Category struct {
+	Authority string `xml:"authority,attr"`
+	Value string `xml:","`
 }
 
 // Impression is a URI that directs the video player to a tracking resource file that

--- a/vast_test.go
+++ b/vast_test.go
@@ -637,3 +637,19 @@ func TestUniversalAdID(t *testing.T) {
 		}
 	}
 }
+
+func TestCategory(t *testing.T) {
+	v, _, _, err := loadFixture("testdata/vast4_universal_ad_id.xml")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "4.0", v.Version)
+	if assert.Len(t, v.Ads, 1) {
+		ad := v.Ads[0]
+		assert.Equal(t, "20008", ad.ID)
+		if assert.NotNil(t, ad.InLine) {
+			assert.NotNil(t,ad.InLine.Categories)
+		}
+	}
+}

--- a/vast_test.go
+++ b/vast_test.go
@@ -390,6 +390,12 @@ func TestWrapperLinear(t *testing.T) {
 					}
 				}
 			}
+
+			if assert.NotNil(t, wrapper.Pricing) {
+				assert.Equal(t, "cpm", wrapper.Pricing.Model)
+				assert.Equal(t, "usd", wrapper.Pricing.Currency)
+				assert.Equal(t, "1.471509", wrapper.Pricing.Value)
+			}
 		}
 	}
 }
@@ -434,6 +440,12 @@ func TestWrapperNonLinear(t *testing.T) {
 						assert.Equal(t, "http://myTrackingURL/wrapper/nonlinear/creativeView/creativeView", crea2.NonLinearAds.TrackingEvents[0].URI)
 					}
 				}
+			}
+
+			if assert.NotNil(t, wrapper.Pricing) {
+				assert.Equal(t, "cpm", wrapper.Pricing.Model)
+				assert.Equal(t, "usd", wrapper.Pricing.Currency)
+				assert.Equal(t, "1.471509", wrapper.Pricing.Value)
 			}
 		}
 	}
@@ -649,9 +661,9 @@ func TestCategory(t *testing.T) {
 		ad := v.Ads[0]
 		assert.Equal(t, "20008", ad.ID)
 		if assert.NotNil(t, ad.InLine) {
-			if assert.NotNil(t,ad.InLine.Categories){
-				assert.Equal(t, "AD CONTENT description category",ad.InLine.Categories[0].Value)
-				assert.Equal(t, "http://www.iabtechlab.com/categoryauthority",ad.InLine.Categories[0].Authority)
+			if assert.NotNil(t, ad.InLine.Categories) {
+				assert.Equal(t, "AD CONTENT description category", ad.InLine.Categories[0].Value)
+				assert.Equal(t, "http://www.iabtechlab.com/categoryauthority", ad.InLine.Categories[0].Authority)
 			}
 		}
 	}

--- a/vast_test.go
+++ b/vast_test.go
@@ -649,7 +649,10 @@ func TestCategory(t *testing.T) {
 		ad := v.Ads[0]
 		assert.Equal(t, "20008", ad.ID)
 		if assert.NotNil(t, ad.InLine) {
-			assert.NotNil(t,ad.InLine.Categories)
+			if assert.NotNil(t,ad.InLine.Categories){
+				assert.Equal(t, "AD CONTENT description category",ad.InLine.Categories[0].Value)
+				assert.Equal(t, "http://www.iabtechlab.com/categoryauthority",ad.InLine.Categories[0].Authority)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Pricing data can appear in wrapper. Adding into help catch pricing from partners who include pricing data in the `Wrapper`, but not the subsequent `InLine`